### PR TITLE
Performance fixes

### DIFF
--- a/network/conn_test.go
+++ b/network/conn_test.go
@@ -70,7 +70,7 @@ func testConn(c0, c1 *Connection, msgs []req) error {
 						r.err = msg.Err
 					} else {
 						var payload []byte
-						if err := rlp.DecodeBytes(msg.Payload, &payload); err != nil {
+						if err := rlp.Decode(msg.Payload, &payload); err != nil {
 							r.err = err
 						} else {
 							r.msg = message{code: msg.Code, payload: payload}


### PR DESCRIPTION
This PR fixes a couple of performance and memory leaks.

- Discover probe nodes used to be done concurrently and it could spawn thousands of routines at the same time. Now, there are 4 probeTasks that probe nodes.
- Discover uses a buffer to receive the packets.
- Use io.Reader instead of bytes when moving the rlp objects along the stack.
- Queue only keeps at most 2 complete sets of elements (100 blocks) before writing into the database.