### PR TITLE
Pow consensus algorithm

### DIFF
--- a/consensus/consensus.go
+++ b/consensus/consensus.go
@@ -47,5 +47,4 @@ type Config struct {
 type Factory func(context.Context, *Config) (Consensus, error)
 
 // TODO, remove close method and use the context
-// TODO, introduce factory method for ethash
 // TODO, move prepare to seal

--- a/consensus/pow/pow.go
+++ b/consensus/pow/pow.go
@@ -1,0 +1,83 @@
+package pow
+
+import (
+	"context"
+	crand "crypto/rand"
+	"fmt"
+	"math"
+	"math/big"
+	"math/rand"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/umbracle/minimal/consensus"
+	"github.com/umbracle/minimal/state"
+)
+
+var (
+	two256 = new(big.Int).Exp(big.NewInt(2), big.NewInt(256), big.NewInt(0))
+)
+
+// Pow is a vanilla proof-of-work engine with a fixed difficulty
+type Pow struct {
+	difficulty *big.Int
+}
+
+func Factory(ctx context.Context, config *consensus.Config) (consensus.Consensus, error) {
+	return &Pow{}, nil
+}
+
+func (p *Pow) VerifyHeader(parent *types.Header, header *types.Header, uncle, seal bool) error {
+	if header.Time.Cmp(parent.Time) <= 0 {
+		return fmt.Errorf("timestamp lower or equal than parent")
+	}
+	if diff := new(big.Int).Sub(header.Number, parent.Number); diff.Cmp(big.NewInt(1)) != 0 {
+		return fmt.Errorf("invalid sequence")
+	}
+	target := new(big.Int).Div(two256, p.difficulty)
+	if big.NewInt(1).SetBytes(header.Hash().Bytes()).Cmp(target) > 0 {
+		return fmt.Errorf("nonce is not correct")
+	}
+	return nil
+}
+
+func (p *Pow) Author(header *types.Header) (common.Address, error) {
+	return common.Address{}, nil
+}
+
+func (p *Pow) Seal(ctx context.Context, block *types.Block) (*types.Block, error) {
+	header := block.Header()
+
+	seed, err := crand.Int(crand.Reader, big.NewInt(math.MaxInt64))
+	if err != nil {
+		return nil, err
+	}
+
+	rand := rand.New(rand.NewSource(seed.Int64()))
+	nonce := uint64(rand.Int63())
+
+	target := new(big.Int).Div(two256, p.difficulty)
+
+	for {
+		header.Nonce = types.EncodeNonce(uint64(nonce))
+		hash := header.Hash()
+
+		if big.NewInt(1).SetBytes(hash.Bytes()).Cmp(target) < 0 {
+			break
+		}
+		nonce++
+	}
+	return types.NewBlockWithHeader(header), nil
+}
+
+func (p *Pow) Prepare(parent *types.Header, header *types.Header) error {
+	return nil
+}
+
+func (p *Pow) Finalize(txn *state.Txn, block *types.Block) error {
+	return nil
+}
+
+func (p *Pow) Close() error {
+	return nil
+}

--- a/consensus/pow/pow_test.go
+++ b/consensus/pow/pow_test.go
@@ -1,0 +1,35 @@
+package pow
+
+import (
+	"context"
+	"math/big"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/core/types"
+)
+
+func TestPow(t *testing.T) {
+	c := &Pow{
+		difficulty: big.NewInt(100),
+	}
+
+	parent := &types.Header{
+		Number: big.NewInt(0),
+		Time:   big.NewInt(0),
+	}
+
+	header := &types.Header{
+		ParentHash: parent.Hash(),
+		Number:     big.NewInt(1),
+		Time:       big.NewInt(1),
+	}
+
+	b, err := c.Seal(context.Background(), types.NewBlockWithHeader(header))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := c.VerifyHeader(parent, b.Header(), true, true); err != nil {
+		t.Fatal(err)
+	}
+}


### PR DESCRIPTION
This PR adds a new consensus algorithm based in a vanilla POW. Ethash generates too much overhead during POW (generate DAG) to be used during some integration tests.