### PR TITLE
Use crypto/x/sha3

### DIFF
--- a/consensus/ethash/algorithm.go
+++ b/consensus/ethash/algorithm.go
@@ -14,7 +14,7 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/bitutil"
 	"github.com/ethereum/go-ethereum/crypto"
-	"github.com/ethereum/go-ethereum/crypto/sha3"
+	"golang.org/x/crypto/sha3"
 )
 
 const (
@@ -106,7 +106,7 @@ func seedHash(block uint64) []byte {
 	if block < epochLength {
 		return seed
 	}
-	keccak256 := makeHasher(sha3.NewKeccak256())
+	keccak256 := makeHasher(sha3.NewLegacyKeccak256())
 	for i := 0; i < int(block/epochLength); i++ {
 		keccak256(seed, seed)
 	}
@@ -163,7 +163,7 @@ func generateCache(dest []uint32, epoch uint64, seed []byte) {
 		}
 	}()
 	// Create a hasher to reuse between invocations
-	keccak512 := makeHasher(sha3.NewKeccak512())
+	keccak512 := makeHasher(sha3.NewLegacyKeccak256())
 
 	// Sequentially produce the initial dataset
 	keccak512(cache, seed)
@@ -297,7 +297,7 @@ func generateDataset(dest []uint32, epoch uint64, cache []uint32) {
 			defer pend.Done()
 
 			// Create a hasher to reuse between invocations
-			keccak512 := makeHasher(sha3.NewKeccak512())
+			keccak512 := makeHasher(sha3.NewLegacyKeccak256())
 
 			// Calculate the data segment this thread should generate
 			batch := uint32((size + hashBytes*uint64(threads) - 1) / (hashBytes * uint64(threads)))
@@ -371,7 +371,7 @@ func hashimoto(hash []byte, nonce uint64, size uint64, lookup func(index uint32)
 // in-memory cache) in order to produce our final value for a particular header
 // hash and nonce.
 func hashimotoLight(size uint64, cache []uint32, hash []byte, nonce uint64) ([]byte, []byte) {
-	keccak512 := makeHasher(sha3.NewKeccak512())
+	keccak512 := makeHasher(sha3.NewLegacyKeccak256())
 
 	lookup := func(index uint32) []uint32 {
 		rawData := generateDatasetItem(cache, index, keccak512)

--- a/consensus/ethash/sealer.go
+++ b/consensus/ethash/sealer.go
@@ -13,9 +13,9 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
-	"github.com/ethereum/go-ethereum/crypto/sha3"
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/rlp"
+	"golang.org/x/crypto/sha3"
 )
 
 const (
@@ -96,7 +96,7 @@ func (e *Ethash) Seal(ctx context.Context, block *types.Block) (*types.Block, er
 
 // SealHash returns the hash of a block prior to it being sealed.
 func (e *Ethash) sealHash(header *types.Header) (hash common.Hash) {
-	hasher := sha3.NewKeccak256()
+	hasher := sha3.NewLegacyKeccak256()
 
 	rlp.Encode(hasher, []interface{}{
 		header.ParentHash,

--- a/network/transport/rlpx/handshake.go
+++ b/network/transport/rlpx/handshake.go
@@ -20,9 +20,10 @@ import (
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/crypto/ecies"
 	"github.com/ethereum/go-ethereum/crypto/secp256k1"
-	"github.com/ethereum/go-ethereum/crypto/sha3"
 	"github.com/ethereum/go-ethereum/rlp"
 	"github.com/umbracle/minimal/helper/enode"
+
+	"golang.org/x/crypto/sha3"
 )
 
 const (
@@ -448,10 +449,10 @@ func (h *handshakeState) Secrets(auth, authResp []byte) (Secrets, error) {
 	}
 
 	// setup sha3 instances for the MACs
-	mac1 := sha3.NewKeccak256()
+	mac1 := sha3.NewLegacyKeccak256()
 	mac1.Write(xor(s.MAC, h.respNonce))
 	mac1.Write(auth)
-	mac2 := sha3.NewKeccak256()
+	mac2 := sha3.NewLegacyKeccak256()
 	mac2.Write(xor(s.MAC, h.initNonce))
 	mac2.Write(authResp)
 	if h.isClient {

--- a/protocol/ethereum/handler.go
+++ b/protocol/ethereum/handler.go
@@ -17,11 +17,11 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/crypto"
-	"github.com/ethereum/go-ethereum/crypto/sha3"
 	"github.com/ethereum/go-ethereum/eth/downloader"
 	"github.com/ethereum/go-ethereum/rlp"
 	multierror "github.com/hashicorp/go-multierror"
 	"github.com/umbracle/minimal/network/transport/rlpx"
+	"golang.org/x/crypto/sha3"
 )
 
 const (
@@ -838,7 +838,7 @@ func (e *Ethereum) Data(data [][]byte) {
 }
 
 func encodeHash(x common.Hash, y common.Hash) common.Hash {
-	hw := sha3.NewKeccak256()
+	hw := sha3.NewLegacyKeccak256()
 	if _, err := hw.Write(x.Bytes()); err != nil {
 		panic(err)
 	}

--- a/state/trie/trie.go
+++ b/state/trie/trie.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 
 	"github.com/ethereum/go-ethereum/common"
-	"github.com/ethereum/go-ethereum/crypto/sha3"
+	"golang.org/x/crypto/sha3"
 )
 
 // Merkle-trie based on hashicorp go-immutable-radix
@@ -289,7 +289,7 @@ func concat(a, b []byte) []byte {
 }
 
 func hashit(b []byte) []byte {
-	f := sha3.NewKeccak256()
+	f := sha3.NewLegacyKeccak256()
 	f.Write(b)
 	res := f.Sum(nil)
 	return res


### PR DESCRIPTION
This PR replaces the go-ethereum sha3 for golang.org/crypto/x/sha3 library.