### PR TITLE
Use correct path on peerstore

### DIFF
--- a/network/peerstore.go
+++ b/network/peerstore.go
@@ -32,7 +32,7 @@ func (p *PeerStore) Update(addr string, status Status) {
 }
 
 func (p *PeerStore) Load() []string {
-	if _, err := os.Stat(peersFile); os.IsNotExist(err) {
+	if _, err := os.Stat(p.path); os.IsNotExist(err) {
 		return []string{}
 	}
 


### PR DESCRIPTION
Peerstore now uses the internal path created by minimal to store the network peers info. There fill be a followup PR with tests for peerstore and to complete the tests in network