### PR TITLE
Optimize ethash cache lookup

### DIFF
--- a/consensus/ethash/cache.go
+++ b/consensus/ethash/cache.go
@@ -44,10 +44,9 @@ func (c *Cache) calcDatasetItem(i uint32) []uint32 {
 
 	for j := 0; j < datasetParents; j++ {
 		cacheIndex := fnvOp(i^uint32(j), mix[j%r])
-
-		// fnv map
+		aux := c.cache[cacheIndex%n]
 		for o := 0; o < 16; o++ {
-			mix[o] = fnvOp(mix[o], c.cache[cacheIndex%n][o])
+			mix[o] = fnvOp(mix[o], aux[o])
 		}
 	}
 


### PR DESCRIPTION
This PR fixes an slowdown introduced in the last refactor of Ethash. The slowdown was in the verification of the headers. There is another bottleneck in the creation of the cache, since the cache is created many times during tests, the CI is a bit slow now.