### PR TITLE
Add metrics endpoint and move metrics sink to minimal

### DIFF
--- a/api/http/http.go
+++ b/api/http/http.go
@@ -42,6 +42,7 @@ func Factory(logger hclog.Logger, m interface{}, config map[string]interface{}) 
 	router := fasthttprouter.New()
 	router.GET("/v1/peers", h.wrap(h.PeersList))
 	router.GET("/v1/peers/:peerid", h.wrap(h.PeersPeerID))
+	router.GET("/v1/metrics", h.wrap(h.Metrics))
 
 	if enableDebug {
 		router.GET("/debug/pprof/", fastAdapt(pprof.Index))

--- a/api/http/metrics_endpoint.go
+++ b/api/http/metrics_endpoint.go
@@ -1,0 +1,33 @@
+package http
+
+import (
+	"net/http"
+	"sync"
+
+	"github.com/prometheus/client_golang/prometheus/promhttp"
+	"github.com/valyala/fasthttp"
+	"github.com/valyala/fasthttp/fasthttpadaptor"
+)
+
+var (
+	promHandler http.Handler
+	promOnce    sync.Once
+)
+
+// Metrics returns several client metrics
+func (h *HTTP) Metrics(ctx *fasthttp.RequestCtx) (interface{}, error) {
+	if string(ctx.QueryArgs().Peek("format")) == "prometheus" {
+		handler := fasthttpadaptor.NewFastHTTPHandler(promhttp.Handler())
+		handler(ctx)
+
+		return nil, nil
+	}
+
+	var res interface{}
+	var err error
+
+	fasthttpadaptor.NewFastHTTPHandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		res, err = h.m.InmemSink.DisplayMetrics(w, r)
+	})(ctx)
+	return res, err
+}

--- a/command/agent/agent.go
+++ b/command/agent/agent.go
@@ -3,11 +3,7 @@ package agent
 import (
 	"fmt"
 	"log"
-	"net"
-	"net/http"
 	"os"
-	"strconv"
-	"time"
 
 	"github.com/umbracle/minimal/api"
 	"github.com/umbracle/minimal/blockchain/storage"
@@ -16,10 +12,6 @@ import (
 	"github.com/umbracle/minimal/network/discovery"
 
 	"github.com/umbracle/minimal/protocol"
-
-	metrics "github.com/armon/go-metrics"
-	"github.com/armon/go-metrics/prometheus"
-	"github.com/prometheus/client_golang/prometheus/promhttp"
 
 	"github.com/umbracle/minimal/chain"
 	"github.com/umbracle/minimal/minimal"
@@ -77,7 +69,6 @@ func NewAgent(logger *log.Logger, config *Config) *Agent {
 
 // Start starts the agent
 func (a *Agent) Start() error {
-	a.startTelemetry()
 
 	var f func(str string) (*chain.Chain, error)
 	if _, err := os.Stat(a.config.Chain); err == nil {
@@ -194,39 +185,4 @@ func (a *Agent) Start() error {
 
 func (a *Agent) Close() {
 	a.minimal.Close()
-}
-
-// TODO, start the api service and connect the internal api with metrics
-func (a *Agent) startTelemetry() {
-	memSink := metrics.NewInmemSink(10*time.Second, time.Minute)
-	metrics.DefaultInmemSignal(memSink)
-
-	metricsConf := metrics.DefaultConfig("minimal")
-	metricsConf.EnableHostnameLabel = false
-	metricsConf.HostName = ""
-
-	var sinks metrics.FanoutSink
-
-	prom, err := prometheus.NewPrometheusSink()
-	if err != nil {
-		panic(err)
-	}
-
-	sinks = append(sinks, prom)
-	sinks = append(sinks, memSink)
-
-	metrics.NewGlobal(metricsConf, sinks)
-
-	l, err := net.Listen("tcp", "localhost:"+strconv.Itoa(a.config.Telemetry.PrometheusPort))
-	if err != nil {
-		panic(err)
-	}
-
-	mux := http.NewServeMux()
-	mux.HandleFunc("/metrics", func(resp http.ResponseWriter, req *http.Request) {
-		handler := promhttp.Handler()
-		handler.ServeHTTP(resp, req)
-	})
-
-	go http.Serve(l, mux)
 }


### PR DESCRIPTION
This PR introduces a new /metrics endpoint. It returns metrics in json format or in Prometheus format with the flag /metrics?format=prometheus.