### PR TITLE
Separate wire protocol from backend protocol

### DIFF
--- a/api/http/peers_endpoint.go
+++ b/api/http/peers_endpoint.go
@@ -3,7 +3,7 @@ package http
 import (
 	"fmt"
 
-	"github.com/umbracle/minimal/protocol"
+	"github.com/umbracle/minimal/network/common"
 	"github.com/valyala/fasthttp"
 )
 
@@ -26,9 +26,9 @@ func (h *HTTP) PeersPeerID(ctx *fasthttp.RequestCtx) (interface{}, error) {
 	}
 
 	// format data
-	protocols := []protocol.Protocol{}
+	protocols := []*common.Instance{}
 	for _, p := range peer.GetProtocols() {
-		protocols = append(protocols, p.Protocol)
+		protocols = append(protocols, p)
 	}
 	info := map[string]interface{}{
 		"client":    peer.Info.Client,

--- a/command/peers_info.go
+++ b/command/peers_info.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 
 	"github.com/mitchellh/mapstructure"
-	"github.com/umbracle/minimal/protocol"
+	"github.com/umbracle/minimal/network/common"
 )
 
 type PeersInfoCommand struct {
@@ -55,7 +55,7 @@ func (p *PeersInfoCommand) formatInfo(info map[string]interface{}) int {
 	p.Ui.Output(p.Colorize().Color("[bold]Info[reset]"))
 	p.Ui.Output(formatKV(data))
 
-	var protos []protocol.Protocol
+	var protos []common.Instance
 	if err := mapstructure.Decode(info["protocols"], &protos); err != nil {
 		// TODO, handle this error
 		return 1
@@ -65,7 +65,7 @@ func (p *PeersInfoCommand) formatInfo(info map[string]interface{}) int {
 	caps[0] = "Name|Version"
 
 	for indx, c := range protos {
-		caps[indx+1] = fmt.Sprintf("%s|%d", c.Name, c.Version)
+		caps[indx+1] = fmt.Sprintf("%s|%d", c.Protocol.Spec.Name, c.Protocol.Spec.Version)
 	}
 
 	p.Ui.Output(p.Colorize().Color("\n[bold]Capabilities[reset]"))

--- a/minimal/minimal.go
+++ b/minimal/minimal.go
@@ -200,7 +200,7 @@ func NewMinimal(logger *log.Logger, config *Config) (*Minimal, error) {
 
 	// Register backends
 	for _, i := range m.backends {
-		if err := m.server.RegisterProtocol(i); err != nil {
+		if err := m.server.RegisterProtocol(i.Protocols()); err != nil {
 			return nil, err
 		}
 	}

--- a/network/common/info.go
+++ b/network/common/info.go
@@ -1,9 +1,28 @@
 package common
 
 import (
+	"net"
+
 	"github.com/umbracle/minimal/helper/enode"
-	"github.com/umbracle/minimal/protocol"
 )
+
+// Protocol is a wire protocol
+type Protocol struct {
+	Spec      ProtocolSpec
+	HandlerFn func(conn net.Conn, peerID string) (ProtocolHandler, error)
+}
+
+// ProtocolHandler is the handler of the protocol
+type ProtocolHandler interface {
+	Info() (map[string]interface{}, error)
+}
+
+// ProtocolSpec is a specification of an etheruem protocol
+type ProtocolSpec struct {
+	Name    string
+	Version uint
+	Length  uint64
+}
 
 // Info is the information of a peer
 type Info struct {
@@ -15,8 +34,7 @@ type Info struct {
 
 // Capability is a feature of the peer
 type Capability struct {
-	Protocol protocol.Protocol
-	Backend  protocol.Backend
+	Protocol Protocol
 }
 
 // Capabilities is a list of capabilities of the peer

--- a/network/common/transport.go
+++ b/network/common/transport.go
@@ -5,19 +5,15 @@ import (
 	"net"
 
 	"github.com/umbracle/minimal/helper/enode"
-	"github.com/umbracle/minimal/protocol"
 )
 
 type Instance struct {
-	Protocol protocol.Protocol
-	Handler  protocol.Handler
+	Protocol *Protocol
+	Handler  ProtocolHandler
 }
 
 // Session is an open connection between two peers
 type Session interface {
-	// OpenStream opens a new stream within the session
-	// OpenStream() (net.Conn, error)
-
 	// NegociateProtocols negociates the sub-protocols
 	NegociateProtocols(info *Info) ([]*Instance, error)
 
@@ -34,7 +30,7 @@ type Session interface {
 // Transport is a generic network transport protocol
 type Transport interface {
 	// Setup starts the protocol with the given private key
-	Setup(priv *ecdsa.PrivateKey, backends []protocol.Backend, info *Info)
+	Setup(priv *ecdsa.PrivateKey, backends []*Protocol, info *Info)
 
 	// Connect connects with the remove connection
 	Connect(net.Conn, enode.Enode) (Session, error)

--- a/network/peer.go
+++ b/network/peer.go
@@ -70,7 +70,7 @@ func (p *Peer) GetProtocols() []*common.Instance {
 // GetProtocol returns the protocol by name
 func (p *Peer) GetProtocol(name string) (*common.Instance, bool) {
 	for _, i := range p.protocols {
-		if i.Protocol.Name == name {
+		if i.Protocol.Spec.Name == name {
 			return i, true
 		}
 	}

--- a/network/transport/rlpx/rlpx.go
+++ b/network/transport/rlpx/rlpx.go
@@ -6,20 +6,19 @@ import (
 
 	"github.com/umbracle/minimal/helper/enode"
 	"github.com/umbracle/minimal/network/common"
-	"github.com/umbracle/minimal/protocol"
 )
 
 // Rlpx is the RLPx transport protocol
 type Rlpx struct {
 	priv     *ecdsa.PrivateKey
-	backends []protocol.Backend
+	backends []*common.Protocol
 	info     *common.Info
 }
 
 // getProtocol returns a protocol
-func (r *Rlpx) getProtocol(name string, version uint) protocol.Backend {
+func (r *Rlpx) getProtocol(name string, version uint) *common.Protocol {
 	for _, p := range r.backends {
-		proto := p.Protocol()
+		proto := p.Spec
 		if proto.Name == name && proto.Version == version {
 			return p
 		}
@@ -53,7 +52,7 @@ func (r *Rlpx) Accept(rawConn net.Conn) (common.Session, error) {
 }
 
 // Setup implements the transport interface
-func (r *Rlpx) Setup(priv *ecdsa.PrivateKey, backends []protocol.Backend, info *common.Info) {
+func (r *Rlpx) Setup(priv *ecdsa.PrivateKey, backends []*common.Protocol, info *common.Info) {
 	r.priv = priv
 	r.backends = backends
 	r.info = info
@@ -78,7 +77,7 @@ func networkInfoToLocalInfo(info *common.Info) *Info {
 		ID:         info.Enode.ID,
 	}
 	for _, cap := range info.Capabilities {
-		p := cap.Protocol
+		p := cap.Protocol.Spec
 		rlpxInfo.Caps = append(rlpxInfo.Caps, &Cap{Name: p.Name, Version: p.Version})
 	}
 	return rlpxInfo

--- a/protocol/ethereum/backend.go
+++ b/protocol/ethereum/backend.go
@@ -16,6 +16,8 @@ import (
 	"sync"
 	"time"
 
+	protoCommon "github.com/umbracle/minimal/network/common"
+
 	metrics "github.com/armon/go-metrics"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
@@ -112,16 +114,23 @@ func NewBackend(minimal *minimal.Minimal, blockchain *blockchain.Blockchain) (*B
 }
 
 // ETH63 is the Fast synchronization protocol
-var ETH63 = protocol.Protocol{
+var ETH63 = protoCommon.ProtocolSpec{
 	Name:    "eth",
 	Version: 63,
 	Length:  17,
 }
 
-func (b *Backend) Protocol() protocol.Protocol {
-	return ETH63
+// Protocols implements the protocol interface
+func (b *Backend) Protocols() []*protoCommon.Protocol {
+	return []*protoCommon.Protocol{
+		&protoCommon.Protocol{
+			Spec:      ETH63,
+			HandlerFn: b.Add,
+		},
+	}
 }
 
+// Run implements the protocol interface
 func (b *Backend) Run() {
 	go b.runSync()
 	go b.commitData()
@@ -294,7 +303,7 @@ func (b *Backend) updateChain(block uint64) {
 }
 
 // Add is called when we connect to a new node
-func (b *Backend) Add(conn net.Conn, peerID string) (protocol.Handler, error) {
+func (b *Backend) Add(conn net.Conn, peerID string) (protoCommon.ProtocolHandler, error) {
 	fmt.Println("----- ADD NODE -----")
 	fmt.Println(peerID)
 

--- a/protocol/protocol.go
+++ b/protocol/protocol.go
@@ -2,26 +2,14 @@ package protocol
 
 import (
 	"context"
-	"net"
+
+	"github.com/umbracle/minimal/network/common"
 )
-
-// Protocol is a specification of an etheruem protocol
-type Protocol struct {
-	Name    string
-	Version uint
-	Length  uint64
-}
-
-// Handler is a backend reference of the peer
-type Handler interface {
-	Info() (map[string]interface{}, error)
-}
 
 // Backend is a protocol backend
 type Backend interface {
-	Protocol() Protocol
+	Protocols() []*common.Protocol
 	Run()
-	Add(conn net.Conn, peerID string) (Handler, error)
 }
 
 // Factory is the factory method to create the protocol


### PR DESCRIPTION
Lets make first a difference between a backend and a wire protocol. A backend/protocol, is a composable block of logic like the Ethereum sync protocol. A wire protocol is a specific set of wire protocols that will be used inside the p2p connection. There will be followup PRs changing the names to avoid future confusions.

Before, the wire protocol spec was inside the backend spec and each backend was expected to use only one wire protocol.

This PR moves the wire protocol spec to the network package and allows each backend to define several wire protocols. This could be useful for versioning different wire protocols inside the same backend.