### PR TITLE
Fix devp2p go routines sync during tests

### DIFF
--- a/network/discovery/devp2p/mock_transport.go
+++ b/network/discovery/devp2p/mock_transport.go
@@ -29,7 +29,7 @@ func (m *MockNetwork) NewTransport() Transport {
 	t := &MockTransport{
 		net:      m,
 		addr:     addr,
-		packetCh: make(chan *Packet),
+		packetCh: make(chan *Packet, 10),
 	}
 	if m.transports == nil {
 		m.transports = make(map[string]*MockTransport)


### PR DESCRIPTION
This PR solves a couple of issues with some devp2p tests failing randomly. As it turns out, during testing the UDP mock transport (and the real UDP transport before that) was too fast and some operations like the delivering of packets were not done sequentially.