### PR TITLE
Feature/rlpv2

### DIFF
--- a/rlp/encode.go
+++ b/rlp/encode.go
@@ -269,9 +269,9 @@ func encodeBool(val reflect.Value, e *Encoder) (*Value, uint, error) {
 	a := e.getValue()
 
 	if val.Bool() {
-		a.buf = boolTrue
+		a.buf = append(a.buf, boolTrue...)
 	} else {
-		a.buf = boolFalse
+		a.buf = append(a.buf, boolFalse...)
 	}
 
 	return a, 0, nil

--- a/rlpv2/decode_v2_test.go
+++ b/rlpv2/decode_v2_test.go
@@ -1,0 +1,97 @@
+package rlpv2
+
+import (
+	"bytes"
+	"fmt"
+	"reflect"
+	"testing"
+
+	"github.com/umbracle/minimal/rlp"
+)
+
+func compare(v interface{}, val *Value) error {
+	return compareImpl(reflect.ValueOf(v), val)
+}
+
+func compareImpl(v reflect.Value, val *Value) error {
+	if v.Kind() == reflect.Array && isByte(v.Type().Elem()) {
+		goto BYTES
+	}
+	if v.Kind() == reflect.Slice && isByte(v.Type().Elem()) {
+		goto BYTES
+	}
+
+	if v.Kind() == reflect.Interface {
+		return compareImpl(v.Elem(), val)
+	}
+	if v.Kind() == reflect.Slice || v.Kind() == reflect.Array || v.Kind() == reflect.Struct {
+		// val should be array
+		if val.t != TypeArray {
+			return fmt.Errorf("array expected but found %s", val.Type())
+		}
+
+		if v.Kind() == reflect.Struct {
+			if v.NumField() != val.Elems() {
+				return fmt.Errorf("elems dont match, expected %d but found %d", val.Elems(), v.NumField())
+			}
+			for i := 0; i < v.NumField(); i++ {
+				if err := compareImpl(v.Field(i), val.Get(i)); err != nil {
+					return err
+				}
+			}
+		} else {
+			if v.Len() != val.Elems() {
+				return fmt.Errorf("elems dont match, expected %d but found %d", val.Elems(), v.Len())
+			}
+			for i := 0; i < v.Len(); i++ {
+				if err := compareImpl(v.Index(i), val.Get(i)); err != nil {
+					return err
+				}
+			}
+		}
+		return nil
+	}
+
+BYTES:
+	if val.t != TypeBytes {
+		return fmt.Errorf("bytes expected but found %s", val.Type())
+	}
+
+	switch v.Kind() {
+	case reflect.Slice:
+		if !bytes.Equal(val.b, v.Bytes()) {
+			return fmt.Errorf("bytes dont match")
+		}
+	default:
+		return fmt.Errorf("type not supported '%s'", v.Kind())
+	}
+	return nil
+}
+
+func TestDecode(t *testing.T) {
+	for i := 0; i < 10000; i++ {
+		t.Run("", func(t *testing.T) {
+			tt := pickRandomType(0)
+			input := generateRandomType(tt)
+
+			data, err := rlp.EncodeToBytes(input)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			v2 := reflect.New(tt.Type()).Interface()
+			if err := rlp.Decode(data, &v2); err != nil {
+				t.Fatal(err)
+			}
+
+			p := Parser{}
+			v, err := p.Parse(data)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if err := compare(v2, v); err != nil {
+				t.Fatal(err)
+			}
+		})
+	}
+}

--- a/rlpv2/encode_v2.go
+++ b/rlpv2/encode_v2.go
@@ -9,6 +9,8 @@ import (
 
 // Optimized RLP encoding library based on fastjson. It will likely replace minimal/rlp in the future.
 
+var DefaultArenaPool ArenaPool
+
 type ArenaPool struct {
 	pool sync.Pool
 }

--- a/rlpv2/encode_v2_test.go
+++ b/rlpv2/encode_v2_test.go
@@ -1,0 +1,120 @@
+package rlpv2
+
+import (
+	"bytes"
+	"math/big"
+	"math/rand"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/umbracle/minimal/helper/hex"
+	"github.com/umbracle/minimal/rlp"
+)
+
+var bigIntTyp = reflect.TypeOf(new(big.Int))
+
+func testEncode(t *testing.T, s interface{}) []byte {
+	a := &Arena{}
+	v := testEncodeImpl(a, t, reflect.ValueOf(s))
+	return v.MarshalTo(nil)
+}
+
+func testEncodeImpl(a *Arena, t *testing.T, v reflect.Value) *Value {
+	if v.Kind() == reflect.Array && isByte(v.Type().Elem()) {
+		return a.NewBytes(v.Slice(0, v.Len()).Bytes())
+	}
+	if v.Kind() == reflect.Slice && isByte(v.Type().Elem()) {
+		return a.NewBytes(v.Bytes())
+	}
+
+	switch v.Kind() {
+	case reflect.Bool:
+		return a.NewBool(v.Bool())
+
+	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+		return a.NewUint(v.Uint())
+
+	case reflect.Ptr:
+		if v.Type() == bigIntTyp {
+			return a.NewBigInt(v.Interface().(*big.Int))
+		}
+		return testEncodeImpl(a, t, v.Elem())
+
+	case reflect.String:
+		return a.NewString(v.String())
+
+	case reflect.Slice:
+		fallthrough
+	case reflect.Array:
+		vv := a.NewArray()
+		for i := 0; i < v.Len(); i++ {
+			vv.Set(testEncodeImpl(a, t, v.Index(i)))
+		}
+		return vv
+
+	case reflect.Struct:
+		vv := a.NewArray()
+		for i := 0; i < v.NumField(); i++ {
+			vv.Set(testEncodeImpl(a, t, v.Field(i)))
+		}
+		return vv
+
+	default:
+		t.Fatalf("failed to encode '%s'", v.Kind().String())
+	}
+	return nil
+}
+
+func TestEncode(t *testing.T) {
+	rand.Seed(time.Now().UTC().UnixNano())
+
+	for i := 0; i < 10000; i++ {
+		t.Run("", func(t *testing.T) {
+			tt := pickRandomType(0)
+			input := generateRandomType(tt)
+
+			out1, err := rlp.EncodeToBytes(input)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			out2 := testEncode(t, input)
+			if !bytes.Equal(out1, out2) {
+				panic("X")
+			}
+		})
+	}
+}
+
+func BenchmarkRlpEncode(b *testing.B) {
+	b.ReportAllocs()
+
+	a := Arena{}
+
+	b1 := hex.MustDecodeHex("0x1111111111111111")
+
+	for i := 0; i < b.N; i++ {
+
+		vv := a.NewArray()
+		vv.Set(a.NewUint(10000000))
+		vv.Set(a.NewBytes([]byte("1000000")))
+		vv.Set(a.NewBytes(b1))
+
+		a.Reset()
+	}
+}
+
+func BenchmarkLegacyRlpEncode(b *testing.B) {
+	b.ReportAllocs()
+
+	data := []interface{}{
+		uint(10000000),
+		"1000000",
+		hex.MustDecodeHex("0x1111111111111111"),
+	}
+
+	for i := 0; i < b.N; i++ {
+		rlp.EncodeToBytes(data)
+	}
+}

--- a/rlpv2/utils_test.go
+++ b/rlpv2/utils_test.go
@@ -1,0 +1,238 @@
+package rlpv2
+
+import (
+	"encoding/hex"
+	"fmt"
+	"math/big"
+	"math/rand"
+	"reflect"
+	"strings"
+)
+
+// Copy from rlp library
+
+func isByte(typ reflect.Type) bool {
+	return typ.Kind() == reflect.Uint8
+}
+
+func randomInt(min, max int) int {
+	return min + rand.Intn(max-min)
+}
+
+const maxDepth = 7
+
+func generateRandom() interface{} {
+	return generateRandomImpl(0)
+}
+
+func generateRandomImpl(depth int) interface{} {
+	n := randomInt(1, 10)
+	if depth == maxDepth {
+		n = 10 // force item
+	}
+	if n < 7 {
+		// list
+		list := []interface{}{}
+		for i := 0; i < randomInt(0, 5); i++ {
+
+			var elem interface{}
+			// 10% chance of having a nil value
+			if randomInt(0, 10) == 1 {
+				elem = nil
+			} else {
+				elem = generateRandomImpl(depth + 1)
+			}
+
+			list = append(list, elem)
+		}
+		return list
+	}
+	// item
+	b := make([]byte, randomInt(0, 100))
+	rand.Read(b)
+	return b
+}
+
+type kind int
+
+const (
+	uintT kind = iota
+	boolT
+	stringT
+	dynamicBytesT
+	fixedBytesT
+	arrayT
+	structT
+)
+
+type typ struct {
+	kind  kind
+	elem  *typ
+	size  int
+	elems []*typ
+}
+
+func (t *typ) Type() reflect.Type {
+	return reflect.TypeOf(generateRandomType(t))
+}
+
+var randomTypes = []string{
+	"uint",
+	"bool",
+	"string",
+	"dynamicbytes",
+	"fixedbytes",
+	"array",
+	"struct",
+}
+
+func randomNumberBits() int {
+	return randomInt(1, 31) * 8
+}
+
+func pickRandomType(d int) *typ {
+PICK:
+	t := randomTypes[rand.Intn(len(randomTypes))]
+
+	switch t {
+	case "uint":
+		return &typ{kind: uintT, size: randomNumberBits()}
+	case "bool":
+		return &typ{kind: boolT}
+	case "string":
+		return &typ{kind: stringT}
+	case "dynamicbytes":
+		return &typ{kind: dynamicBytesT}
+	case "fixedbytes":
+		return &typ{kind: fixedBytesT}
+	}
+
+	if d > 1 {
+		// Allow only for 3 levels of depth
+		goto PICK
+	}
+
+	r := pickRandomType(d + 1)
+	switch t {
+	case "array":
+		return &typ{kind: arrayT, elem: r, size: randomInt(1, 3)}
+
+	case "struct":
+		size := randomInt(1, 5)
+		elems := []*typ{}
+		for i := 0; i < size; i++ {
+			elems = append(elems, pickRandomType(d+1))
+		}
+		return &typ{kind: structT, elems: elems}
+
+	default:
+		panic(fmt.Errorf("type not implemented: %s", t))
+	}
+}
+
+var (
+	uint8T  = reflect.TypeOf(uint8(0))
+	uint16T = reflect.TypeOf(uint16(0))
+	uint32T = reflect.TypeOf(uint32(0))
+	uint64T = reflect.TypeOf(uint64(0))
+)
+
+func mustDecode(str string) []byte {
+	if strings.HasPrefix(str, "0x") {
+		str = str[2:]
+	}
+	b, err := hex.DecodeString(str)
+	if err != nil {
+		panic(err)
+	}
+	return b
+}
+
+func generateNumber(t *typ) interface{} {
+	b := make([]byte, t.size/8)
+	rand.Read(b)
+
+	var typ reflect.Type
+	switch t.size {
+	case 8:
+		typ = uint8T
+	case 16:
+		typ = uint16T
+	case 32:
+		typ = uint32T
+	case 64:
+		typ = uint64T
+	}
+
+	num := big.NewInt(1).SetBytes(b)
+	if t.size == 8 || t.size == 16 || t.size == 32 || t.size == 64 {
+		return reflect.ValueOf(num.Int64()).Convert(typ).Interface()
+	}
+	return num
+}
+
+func generateRandomType(t *typ) interface{} {
+
+	switch t.kind {
+	case uintT:
+		return generateNumber(t)
+
+	case boolT:
+		if randomInt(0, 2) == 1 {
+			return true
+		}
+		return false
+
+	case stringT:
+		return randString(randomInt(1, 100), dictLetters)
+
+	case fixedBytesT:
+		return mustDecode(randString(32, hexLetters))
+
+	case dynamicBytesT:
+		buf := make([]byte, randomInt(1, 100))
+		rand.Read(buf)
+		return buf
+
+	case arrayT:
+		size := randomInt(0, 5)
+		val := reflect.MakeSlice(reflect.SliceOf(t.elem.Type()), size, size)
+
+		for i := 0; i < size; i++ {
+			val.Index(i).Set(reflect.ValueOf(generateRandomType(t.elem)))
+		}
+		return val.Interface()
+
+	case structT:
+		fields := []reflect.StructField{}
+		for indx, elem := range t.elems {
+			fields = append(fields, reflect.StructField{
+				Name: fmt.Sprintf("Arg%d", indx),
+				Type: elem.Type(),
+			})
+		}
+
+		typ := reflect.StructOf(fields)
+		v := reflect.New(typ)
+
+		for i := 0; i < v.Elem().NumField(); i++ {
+			v.Elem().Field(i).Set(reflect.ValueOf(generateRandomType(t.elems[i])))
+		}
+		return v.Interface()
+
+	default:
+		panic(fmt.Errorf("type not implemented: %d", t.kind))
+	}
+}
+
+const hexLetters = "0123456789abcdef"
+
+const dictLetters = "abcdefghijklmenopqrstuvwxyz"
+
+func randString(n int, dict string) string {
+	b := make([]byte, n)
+	for i := range b {
+		b[i] = dict[rand.Intn(len(dict))]
+	}
+	return string(b)
+}

--- a/state/immutable-trie/trie.go
+++ b/state/immutable-trie/trie.go
@@ -559,3 +559,11 @@ func show(obj interface{}, label int, d int) {
 		panic("not expected")
 	}
 }
+
+func extendByteSlice(b []byte, needLen int) []byte {
+	b = b[:cap(b)]
+	if n := needLen - cap(b); n > 0 {
+		b = append(b, make([]byte, n)...)
+	}
+	return b[:needLen]
+}


### PR DESCRIPTION
Move rlp v2 from itrie to his own package and use the v2 encoder to compute CreateAddress. There will be a followup PR replacing rlp encoding with the legacy encoder to the new version. There will likely be more changes to v2 decoder before we can use it reliable.