### PR TITLE
Apply rlpv2 to Header, Txn and Receipt and add keccak hash to rlp arena

### DIFF
--- a/consensus/ethash/ethash.go
+++ b/consensus/ethash/ethash.go
@@ -24,6 +24,9 @@ type Ethash struct {
 	config  *chain.Params
 	cache   *lru.Cache
 	fakePow bool
+
+	// tmp is the seal hash tmp variable
+	tmp []byte
 }
 
 // Factory is the factory method to create an Ethash consensus
@@ -94,7 +97,8 @@ func (e *Ethash) VerifyHeader(parent *types.Header, header *types.Header, uncle,
 		cache := e.getCache(number)
 
 		nonce := binary.BigEndian.Uint64(header.Nonce[:])
-		digest, result := cache.hashimoto(sealHash(header).Bytes(), nonce)
+		hash := e.sealHash(header)
+		digest, result := cache.hashimoto(hash, nonce)
 
 		if !bytes.Equal(header.MixHash[:], digest) {
 			return fmt.Errorf("incorrect digest")

--- a/state/immutable-trie/trie.go
+++ b/state/immutable-trie/trie.go
@@ -115,6 +115,8 @@ func hashit(k []byte) []byte {
 	return h.Sum(nil)
 }
 
+var accountArenaPool rlpv2.ArenaPool
+
 func (t *Trie) Commit(x *iradix.Tree) (state.Snapshot, []byte) {
 	// Create an insertion batch for all the entries
 	batch := t.storage.Batch()
@@ -122,8 +124,8 @@ func (t *Trie) Commit(x *iradix.Tree) (state.Snapshot, []byte) {
 	tt := t.Txn()
 	tt.batch = batch
 
-	arena := rlpv2.DefaultArenaPool.Get()
-	defer rlpv2.DefaultArenaPool.Put(arena)
+	arena := accountArenaPool.Get()
+	defer accountArenaPool.Put(arena)
 
 	x.Root().Walk(func(k []byte, v interface{}) bool {
 		a, ok := v.(*state.StateObject)


### PR DESCRIPTION
This PR uses rlpv2 encoding instead of the legacy rlp encoder that uses reflection.