### PR TITLE
Add Postgresql storage

### DIFF
--- a/blockchain/blockchain_test.go
+++ b/blockchain/blockchain_test.go
@@ -317,7 +317,7 @@ func TestCommitChain(t *testing.T) {
 		assert.Equal(t, i.Transactions[0].Nonce, block.Number())
 
 		// check receipts
-		r := b.db.ReadReceipts(block.Hash())
+		r, _ := b.db.ReadReceipts(block.Hash())
 		assert.Len(t, r, 1)
 	}
 }

--- a/blockchain/storage/badgerdb/badgerdb_test.go
+++ b/blockchain/storage/badgerdb/badgerdb_test.go
@@ -26,8 +26,5 @@ func newStorage(t *testing.T) (storage.Storage, func()) {
 }
 
 func TestStorage(t *testing.T) {
-	s, close := newStorage(t)
-	defer close()
-
-	storage.TestStorage(t, s)
+	storage.TestStorage(t, newStorage)
 }

--- a/blockchain/storage/boltdb/boltdb_test.go
+++ b/blockchain/storage/boltdb/boltdb_test.go
@@ -27,8 +27,5 @@ func newStorage(t *testing.T) (storage.Storage, func()) {
 }
 
 func TestStorage(t *testing.T) {
-	s, close := newStorage(t)
-	defer close()
-
-	storage.TestStorage(t, s)
+	storage.TestStorage(t, newStorage)
 }

--- a/blockchain/storage/keyvalue.go
+++ b/blockchain/storage/keyvalue.go
@@ -100,7 +100,7 @@ func (s *KeyValueStorage) ReadHeadHash() (types.Hash, bool) {
 
 // ReadHeadNumber returns the number of the head
 func (s *KeyValueStorage) ReadHeadNumber() (uint64, bool) {
-	data, ok := s.get(HEAD, HASH)
+	data, ok := s.get(HEAD, NUMBER)
 	if !ok {
 		return 0, false
 	}
@@ -186,10 +186,10 @@ func (s *KeyValueStorage) WriteReceipts(hash types.Hash, receipts []*types.Recei
 }
 
 // ReadReceipts reads the receipts
-func (s *KeyValueStorage) ReadReceipts(hash types.Hash) []*types.Receipt {
+func (s *KeyValueStorage) ReadReceipts(hash types.Hash) ([]*types.Receipt, bool) {
 	var receipts []*types.Receipt
-	s.read(RECEIPTS, hash.Bytes(), &receipts)
-	return receipts
+	ok := s.read(RECEIPTS, hash.Bytes(), &receipts)
+	return receipts, ok
 }
 
 // -- write ops --

--- a/blockchain/storage/leveldb/leveldb_test.go
+++ b/blockchain/storage/leveldb/leveldb_test.go
@@ -26,8 +26,5 @@ func newStorage(t *testing.T) (storage.Storage, func()) {
 }
 
 func TestStorage(t *testing.T) {
-	s, close := newStorage(t)
-	defer close()
-
-	storage.TestStorage(t, s)
+	storage.TestStorage(t, newStorage)
 }

--- a/blockchain/storage/memory/memory_test.go
+++ b/blockchain/storage/memory/memory_test.go
@@ -7,6 +7,9 @@ import (
 )
 
 func TestStorage(t *testing.T) {
-	s, _ := NewMemoryStorage(nil)
-	storage.TestStorage(t, s)
+	f := func(t *testing.T) (storage.Storage, func()) {
+		s, _ := NewMemoryStorage(nil)
+		return s, func() {}
+	}
+	storage.TestStorage(t, f)
 }

--- a/blockchain/storage/postgresql/postgresql.go
+++ b/blockchain/storage/postgresql/postgresql.go
@@ -1,0 +1,350 @@
+package postgresql
+
+import (
+	"database/sql"
+	"math/big"
+	"strings"
+
+	"github.com/jmoiron/sqlx"
+	_ "github.com/lib/pq"
+	"github.com/umbracle/minimal/helper/hex"
+	"github.com/umbracle/minimal/types"
+
+	"fmt"
+
+	"github.com/hashicorp/go-hclog"
+)
+
+// Backend is the postgresql backend
+type Backend struct {
+	db *sqlx.DB
+}
+
+// Factory creates a PostgreSQL storage
+func Factory(config map[string]interface{}, logger hclog.Logger) (*Backend, error) {
+	endpoint, ok := config["endpoint"]
+	if !ok {
+		return nil, fmt.Errorf("endpoint not found")
+	}
+	endpointStr, ok := endpoint.(string)
+	if !ok {
+		return nil, fmt.Errorf("endpoint is not a string")
+	}
+	db, err := sqlx.Connect("postgres", endpointStr)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := db.Ping(); err != nil {
+		return nil, err
+	}
+
+	// Check if the header table is populated
+	var count uint
+	if err := db.Get(&count, "SELECT count(*) FROM header"); err != nil {
+		return nil, err
+	}
+	if count > 1 {
+		return nil, fmt.Errorf("more than one entry in header table")
+	}
+	if count == 0 {
+		// Insert an empty entry in the header
+		if _, err := db.Exec("INSERT INTO header (forks) VALUES ('')"); err != nil {
+			return nil, err
+		}
+	}
+
+	b := &Backend{
+		db: db,
+	}
+	return b, nil
+}
+
+// Close implements the storage interface
+func (b *Backend) Close() error {
+	return b.db.Close()
+}
+
+// WriteReceipts implements the storage interface
+func (b *Backend) WriteReceipts(hash types.Hash, receipts []*types.Receipt) error {
+	// TODO, it does not store logs
+	query := "INSERT INTO receipts (hash, txhash, root, cumulative_gas_used, gas_used, bloom, contract_address) VALUES ($1, $2, $3, $4, $5, $6, $7)"
+
+	tx, err := b.db.Begin()
+	if err != nil {
+		return err
+	}
+	for _, i := range receipts {
+		if _, err := tx.Exec(query, hash.String(), i.TxHash, i.Root, i.CumulativeGasUsed, i.GasUsed, i.LogsBloom, i.ContractAddress); err != nil {
+			return err
+		}
+	}
+	if err := tx.Commit(); err != nil {
+		return err
+	}
+	return nil
+}
+
+// ReadReceipts implements the storage interface
+func (b *Backend) ReadReceipts(hash types.Hash) ([]*types.Receipt, bool) {
+	query := "SELECT txhash, root, cumulative_gas_used, gas_used, bloom, contract_address FROM receipts WHERE hash=$1"
+
+	var receipts []*types.Receipt
+	if err := b.db.Select(&receipts, query, hash); err != nil {
+		return nil, false
+	}
+
+	return receipts, true
+}
+
+func (b *Backend) WriteTransaction(hash types.Hash, t *types.Transaction) error {
+	tx, err := b.db.Begin()
+	if err != nil {
+		return err
+	}
+	if err := b.writeTransactionImpl(tx, hash, t); err != nil {
+		return err
+	}
+	return tx.Commit()
+}
+
+func (b *Backend) writeTransactionImpl(tx *sql.Tx, hash types.Hash, t *types.Transaction) error {
+	query := "INSERT INTO transactions (hash, txhash, nonce, gas_price, gas, dst, value, input, v, r, s) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)"
+
+	if _, err := b.db.Exec(query, hash, t.Hash(), t.Nonce, t.GasPrice, t.Gas, t.To, t.Value.String(), t.Input.String(), int(t.V), t.R.String(), t.S.String()); err != nil {
+		return err
+	}
+	return nil
+}
+
+// ReadTransaction read a transaction by hash
+func (b *Backend) ReadTransaction(hash types.Hash) (*types.Transaction, bool) {
+	query := "SELECT nonce, gas_price, gas, value, dst, input, v, r, s FROM transactions WHERE txhash=$1"
+
+	txn := types.Transaction{}
+	if err := b.db.Get(&txn, query, hash.String()); err != nil {
+		return nil, false
+	}
+
+	hh := txn.Hash()
+	if hh != hash {
+		return nil, false
+	}
+	return &txn, true
+}
+
+// ReadHeader implements the storage backend
+func (b *Backend) ReadHeader(hash types.Hash) (*types.Header, bool) {
+	query := "SELECT parent_hash, sha3_uncles, miner, state_root, transactions_root, receipts_root, logs_bloom, difficulty, number, gas_limit, gas_used, timestamp, extradata, mixhash, nonce FROM headers where hash=$1"
+
+	header := types.Header{}
+	if err := b.db.Get(&header, query, hash.String()); err != nil {
+		// TODO, return error
+		return nil, false
+	}
+
+	hh := header.Hash()
+	if hh != hash {
+		return nil, false
+	}
+	return &header, true
+}
+
+// WriteHeader implements the storage backend
+func (b *Backend) WriteHeader(h *types.Header) error {
+	tx, err := b.db.Begin()
+	if err != nil {
+		return err
+	}
+	if err := b.writeHeaderImpl(tx, h); err != nil {
+		return err
+	}
+	if err := tx.Commit(); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (b *Backend) writeHeaderImpl(tx *sql.Tx, h *types.Header) error {
+	query := `INSERT INTO headers (hash, parent_hash, sha3_uncles, miner, state_root, transactions_root, receipts_root, logs_bloom, difficulty, number, gas_limit, gas_used, timestamp, extradata, mixhash, nonce) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16)`
+
+	if _, err := tx.Exec(query, h.Hash(), h.ParentHash, h.Sha3Uncles, h.Miner, h.StateRoot, h.TxRoot, h.ReceiptsRoot, h.LogsBloom, h.Difficulty, h.Number, h.GasLimit, h.GasUsed, h.Timestamp, h.ExtraData, h.MixHash, hex.EncodeToHex(h.Nonce[:])); err != nil {
+		return err
+	}
+	return nil
+}
+
+// ReadDiff implements the storage backend
+func (b *Backend) ReadDiff(hash types.Hash) (*big.Int, bool) {
+	query := "SELECT difficulty FROM difficulty WHERE hash=$1"
+
+	var diff string
+	if err := b.db.Get(&diff, query, hash.String()); err != nil {
+		return nil, false
+	}
+
+	bb, _ := new(big.Int).SetString(diff, 10)
+	return bb, true
+}
+
+// WriteDiff implements the storage backend
+func (b *Backend) WriteDiff(hash types.Hash, diff *big.Int) error {
+	query := "INSERT INTO difficulty (hash, difficulty) VALUES ($1, $2)"
+
+	if _, err := b.db.Exec(query, hash, diff.String()); err != nil {
+		return err
+	}
+	return nil
+}
+
+// ReadCanonicalHash implements the storage backend
+func (b *Backend) ReadCanonicalHash(n uint64) (types.Hash, bool) {
+	query := "SELECT hash FROM canonical WHERE number=$1"
+
+	var hash types.Hash
+	if err := b.db.Get(&hash, query, n); err != nil {
+		return types.Hash{}, false
+	}
+	return hash, true
+}
+
+// WriteCanonicalHash implements the storage backend
+func (b *Backend) WriteCanonicalHash(n uint64, hash types.Hash) error {
+	query := "INSERT INTO canonical (hash, number) VALUES ($1, $2) ON CONFLICT (number) DO UPDATE SET hash = $1"
+
+	if _, err := b.db.Exec(query, hash.String(), n); err != nil {
+		return err
+	}
+	return nil
+}
+
+// WriteForks implements the storage backend
+func (b *Backend) WriteForks(forks []types.Hash) error {
+	query := "UPDATE header SET forks=$1"
+
+	str := ""
+	for indx, h := range forks {
+		str += h.String()
+		if indx != len(forks)-1 {
+			str += ","
+		}
+	}
+	if _, err := b.db.Exec(query, str); err != nil {
+		return err
+	}
+	return nil
+}
+
+// ReadForks implements the storage backend
+func (b *Backend) ReadForks() []types.Hash {
+	query := "SELECT forks FROM header"
+
+	var str string
+	if err := b.db.Get(&str, query); err != nil {
+		return []types.Hash{}
+	}
+
+	res := []types.Hash{}
+	for _, i := range strings.Split(str, ",") {
+		res = append(res, types.StringToHash(i))
+	}
+	return res
+}
+
+// ReadHeadHash implements the storage backend
+func (b *Backend) ReadHeadHash() (types.Hash, bool) {
+	query := "SELECT hash FROM header"
+
+	var head *string
+	if err := b.db.Get(&head, query); err != nil {
+		return types.Hash{}, false
+	}
+	if head == nil {
+		return types.Hash{}, false
+	}
+	return types.StringToHash(*head), true
+}
+
+// ReadHeadNumber implements the storage backend
+func (b *Backend) ReadHeadNumber() (uint64, bool) {
+	query := "SELECT number FROM header"
+
+	var head uint64
+	if err := b.db.Get(&head, query); err != nil {
+		return 0, false
+	}
+	return head, true
+}
+
+// WriteHeadHash implements the storage backend
+func (b *Backend) WriteHeadHash(h types.Hash) error {
+	query := "UPDATE header SET hash=$1"
+
+	if _, err := b.db.Exec(query, h); err != nil {
+		return err
+	}
+	return nil
+}
+
+// WriteHeadNumber implements the storage backend
+func (b *Backend) WriteHeadNumber(n uint64) error {
+	query := "UPDATE header SET number=$1"
+
+	if _, err := b.db.Exec(query, n); err != nil {
+		return err
+	}
+	return nil
+}
+
+// WriteBody implements the storage backend
+func (b *Backend) WriteBody(hash types.Hash, body *types.Body) error {
+	tx, err := b.db.Begin()
+	if err != nil {
+		return err
+	}
+
+	// write the uncles
+	for _, u := range body.Uncles {
+		if err := b.writeHeaderImpl(tx, u); err != nil {
+			return err
+		}
+		if _, err := tx.Exec("INSERT INTO uncles (hash, uncle) VALUES ($1, $2)", hash, u.Hash()); err != nil {
+			return err
+		}
+	}
+
+	// write the transactions
+	for _, t := range body.Transactions {
+		if err := b.writeTransactionImpl(tx, hash, t); err != nil {
+			return err
+		}
+	}
+
+	if err := tx.Commit(); err != nil {
+		return err
+	}
+	return nil
+}
+
+// ReadBody implements the storage backend
+func (b *Backend) ReadBody(hash types.Hash) (*types.Body, bool) {
+	queryHeaders := "SELECT parent_hash, sha3_uncles, miner, state_root, transactions_root, receipts_root, logs_bloom, difficulty, number, gas_limit, gas_used, timestamp, extradata, mixhash, nonce FROM headers INNER JOIN uncles ON (uncles.uncle = headers.hash) AND uncles.hash=$1"
+
+	uncles := []*types.Header{}
+	if err := b.db.Select(&uncles, queryHeaders, hash); err != nil {
+		return nil, false
+	}
+
+	queryTxs := "SELECT nonce, gas_price, gas, value, dst, input, v, r, s FROM transactions WHERE hash=$1"
+
+	transactions := []*types.Transaction{}
+	if err := b.db.Select(&transactions, queryTxs, hash); err != nil {
+		return nil, false
+	}
+
+	body := &types.Body{
+		Uncles:       uncles,
+		Transactions: transactions,
+	}
+	return body, true
+}

--- a/blockchain/storage/postgresql/postgresql_test.go
+++ b/blockchain/storage/postgresql/postgresql_test.go
@@ -1,0 +1,95 @@
+package postgresql
+
+import (
+	"database/sql"
+	"io/ioutil"
+	"strings"
+	"testing"
+
+	_ "github.com/lib/pq"
+	"github.com/umbracle/minimal/blockchain/storage"
+
+	"github.com/hashicorp/go-hclog"
+)
+
+const endpoint = "user=postgres password=docker sslmode=disable"
+
+func checkPostgreSQLRunning() bool {
+	db, err := sql.Open("postgres", endpoint)
+	if err != nil {
+		panic(err)
+	}
+	if err = db.Ping(); err != nil {
+		return false
+	}
+	return true
+}
+
+func buildDB(t *testing.T) func() {
+	db, err := sql.Open("postgres", endpoint)
+	if err != nil {
+		panic(err)
+	}
+	if err = db.Ping(); err != nil {
+		t.Skip("PostgreSQL is not running")
+	}
+
+	// build tables
+	data, err := ioutil.ReadFile("./schema/schema.sql")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := db.Exec(string(data)); err != nil {
+		t.Fatal(err)
+	}
+
+	// remove the tables with a callback
+	rows, err := db.Query("select table_name from information_schema.tables where table_schema = 'public'")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	tables := []string{}
+	for rows.Next() {
+		var table string
+		if err := rows.Scan(&table); err != nil {
+			t.Fatal(err)
+		}
+		tables = append(tables, table)
+	}
+
+	closeFn := func() {
+		defer db.Close()
+		if _, err := db.Exec("DROP TABLE " + strings.Join(tables, ",") + " CASCADE;"); err != nil {
+			t.Fatal(err)
+		}
+	}
+	return closeFn
+}
+
+func newBackend(t *testing.T) *Backend {
+	c := map[string]interface{}{
+		"endpoint": endpoint,
+	}
+	logger := hclog.New(&hclog.LoggerOptions{
+		Output: ioutil.Discard,
+	})
+	b, err := Factory(c, logger)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return b
+}
+
+func newStorage(t *testing.T) (storage.Storage, func()) {
+	close := buildDB(t)
+	b := newBackend(t)
+	return b, close
+}
+
+func TestStorage(t *testing.T) {
+	if !checkPostgreSQLRunning() {
+		t.Skip("PostgreSQL is not running")
+	}
+	storage.TestStorage(t, newStorage)
+}

--- a/blockchain/storage/postgresql/schema/schema.sql
+++ b/blockchain/storage/postgresql/schema/schema.sql
@@ -1,0 +1,69 @@
+
+CREATE TABLE headers (
+    hash                char(66) PRIMARY KEY,
+    parent_hash         char(66),
+    sha3_uncles         char(66),
+    miner               char(42),
+    state_root          char(66),
+    transactions_root   char(66),
+    receipts_root       char(66),
+    logs_bloom          char(514),
+    difficulty          numeric,
+    number              int,
+    gas_limit           int,
+    gas_used            int,
+    timestamp           int,
+    extradata           text,
+    mixhash             char(66),
+    nonce               char(18)
+);
+
+CREATE TABLE uncles (
+    uncle   char(66),
+    hash    char(66)
+);
+
+CREATE TABLE header (
+    hash    char(66) REFERENCES headers(hash),
+    number  int,
+    forks   text
+);
+
+CREATE TABLE transactions (
+    txhash      char(66) PRIMARY KEY,
+    hash        char(66),
+    nonce       int,
+    gas_price   text,
+    gas         int,
+    dst         char(42),
+    value       text,
+    input       text,
+    v           smallint,
+    r           text,
+    s           text
+);
+
+/*
+TODO, Add 'log' table. It is necessary to include txindex
+and other contextual information in the receipt type.
+*/
+
+CREATE TABLE receipts (
+    hash                char(66) REFERENCES headers(hash),
+    txhash              char(66) REFERENCES transactions(txhash),
+    root                text,
+    cumulative_gas_used int,
+    gas_used            int,
+    bloom               char(514),
+    contract_address    char(42)
+);
+
+CREATE TABLE difficulty (
+    hash        char(66) REFERENCES headers(hash),
+    difficulty  numeric
+);
+
+CREATE TABLE canonical (
+    hash    char(66) REFERENCES headers(hash),
+    number  int UNIQUE
+);

--- a/blockchain/storage/storage.go
+++ b/blockchain/storage/storage.go
@@ -30,7 +30,7 @@ type Storage interface {
 	ReadBody(hash types.Hash) (*types.Body, bool)
 
 	WriteReceipts(hash types.Hash, receipts []*types.Receipt) error
-	ReadReceipts(hash types.Hash) []*types.Receipt
+	ReadReceipts(hash types.Hash) ([]*types.Receipt, bool)
 
 	Close() error
 }


### PR DESCRIPTION
This PR adds support for PostgreSQL storage for the blockchain data (no merkle-tries). There are some constraints regarding body data (transactions and uncles) that are not enforced in the SQL schemes (i.e. transaction header hash does not reference the hash field in the header). The reason is that the blockchain logic writes the body data before the header because it is necessary to validate the uncles. There will be a followup PR to refactor the uncles logic to not depend on storage data.