### PR TITLE
Add caches to blockchain and transaction write of the canonical header

### DIFF
--- a/blockchain/storage/keyvalue.go
+++ b/blockchain/storage/keyvalue.go
@@ -164,6 +164,26 @@ func (s *KeyValueStorage) ReadHeader(hash types.Hash) (*types.Header, bool) {
 	return header, ok
 }
 
+// WriteCanonicalHeader implements the storage interface
+func (s *KeyValueStorage) WriteCanonicalHeader(h *types.Header, diff *big.Int) error {
+	if err := s.WriteHeader(h); err != nil {
+		return err
+	}
+	if err := s.WriteHeadHash(h.Hash()); err != nil {
+		return err
+	}
+	if err := s.WriteHeadNumber(h.Number); err != nil {
+		return err
+	}
+	if err := s.WriteCanonicalHash(h.Number, h.Hash()); err != nil {
+		return err
+	}
+	if err := s.WriteDiff(h.Hash(), diff); err != nil {
+		return err
+	}
+	return nil
+}
+
 // -- body --
 
 // WriteBody writes the body

--- a/blockchain/storage/storage.go
+++ b/blockchain/storage/storage.go
@@ -26,6 +26,8 @@ type Storage interface {
 	WriteHeader(h *types.Header) error
 	ReadHeader(hash types.Hash) (*types.Header, bool)
 
+	WriteCanonicalHeader(h *types.Header, diff *big.Int) error
+
 	WriteBody(hash types.Hash, body *types.Body) error
 	ReadBody(hash types.Hash) (*types.Body, bool)
 


### PR DESCRIPTION
This PR does two things:

- Includes caches for bodies and receipts.
- Adds a new method to the storage to write a canonical hash (i.e. the new head of the chain).
