### PR TITLE
Disable receipts download during eth62 sync

### DIFF
--- a/protocol/ethereum/backend.go
+++ b/protocol/ethereum/backend.go
@@ -98,6 +98,7 @@ func NewBackend(minimal *minimal.Minimal, logger hclog.Logger, blockchain *block
 
 	b.queue.front = b.queue.newItem(header.Number + 1)
 	b.queue.head = header.Hash()
+	b.queue.DisableReceipts()
 
 	logger.Info("Header", "num", header.Number, "hash", header.Hash().String())
 

--- a/protocol/ethereum/queue.go
+++ b/protocol/ethereum/queue.go
@@ -35,14 +35,19 @@ const (
 )
 
 type queue struct {
-	front, back *element
-	seq         uint32
-	head        types.Hash // head of the sync chain
-	lock        *sync.Mutex
+	front, back     *element
+	seq             uint32
+	head            types.Hash // head of the sync chain
+	lock            *sync.Mutex
+	disableReceipts bool
 }
 
 func newQueue() *queue {
 	return &queue{lock: &sync.Mutex{}}
+}
+
+func (q *queue) DisableReceipts() {
+	q.disableReceipts = true
 }
 
 func (q *queue) addBack(block uint64) {
@@ -143,7 +148,7 @@ func (q *queue) deliverHeaders(id uint32, headers []*types.Header) error {
 		}
 	}
 
-	if len(receipts) != 0 {
+	if !q.disableReceipts && len(receipts) != 0 {
 		elem.receiptsStatus = waitingX
 		elem.receiptsHeaders = receipts
 	}


### PR DESCRIPTION
There is no point in downloading receipts in the ethereum protocol since it only works in fast/archive mode. This PR adds a new flag to the download queue so that we can switch or not to download the receipts. It can be enabled later on for the fast sync.