### PR TITLE
Remove iradix from itrie

### DIFF
--- a/state/immutable-trie/trie.go
+++ b/state/immutable-trie/trie.go
@@ -9,8 +9,6 @@ import (
 	"github.com/umbracle/minimal/state"
 	"github.com/umbracle/minimal/types"
 	"golang.org/x/crypto/sha3"
-
-	iradix "github.com/hashicorp/go-immutable-radix"
 )
 
 // Node represents a node reference
@@ -125,7 +123,7 @@ var accountArenaPool fastrlp.ArenaPool
 
 var stateArenaPool fastrlp.ArenaPool // TODO, Remove once we do update in fastrlp
 
-func (t *Trie) Commit(x *iradix.Tree) (state.Snapshot, []byte) {
+func (t *Trie) Commit(objs []*state.Object) (state.Snapshot, []byte) {
 	// Create an insertion batch for all the entries
 	batch := t.storage.Batch()
 
@@ -138,63 +136,56 @@ func (t *Trie) Commit(x *iradix.Tree) (state.Snapshot, []byte) {
 	ar1 := stateArenaPool.Get()
 	defer stateArenaPool.Put(ar1)
 
-	x.Root().Walk(func(k []byte, v interface{}) bool {
-		a, ok := v.(*state.StateObject)
-		if !ok {
-			// We also have logs, avoid those
-			return false
-		}
+	for _, obj := range objs {
+		if obj.Deleted {
+			tt.Delete(hashit(obj.Address.Bytes()))
+		} else {
 
-		if a.Deleted {
-			tt.Delete(hashit(k))
-			return false
-		}
+			account := state.Account{
+				Balance:  obj.Balance,
+				Nonce:    obj.Nonce,
+				CodeHash: obj.CodeHash.Bytes(),
+				Root:     obj.Root, // old root
+			}
 
-		// compute first the state changes
-		if a.Txn != nil {
-			localTxn := a.Account.Trie.(*Trie).Txn()
-			localTxn.batch = batch
-
-			// Apply all the changes
-			a.Txn.Root().Walk(func(k []byte, v interface{}) bool {
-				if v == nil {
-					localTxn.Delete(k)
-				} else {
-					vv := ar1.NewBytes(bytes.TrimLeft(v.([]byte), "\x00"))
-					localTxn.Insert(k, vv.MarshalTo(nil))
+			if len(obj.Storage) != 0 {
+				localSnapshot, err := t.state.NewSnapshotAt(obj.Root)
+				if err != nil {
+					panic(err)
 				}
-				return false
-			})
 
-			accountStateRoot, _ := localTxn.Hash()
-			accountStateTrie := localTxn.Commit()
+				localTxn := localSnapshot.(*Trie).Txn()
+				localTxn.batch = batch
 
-			// Add this to the cache
-			t.state.AddState(types.BytesToHash(accountStateRoot), accountStateTrie)
+				for _, entry := range obj.Storage {
+					if entry.Deleted {
+						localTxn.Delete(entry.Key)
+					} else {
+						vv := ar1.NewBytes(bytes.TrimLeft(entry.Val, "\x00"))
+						localTxn.Insert(entry.Key, vv.MarshalTo(nil))
+					}
+				}
 
-			a.Account.Root = types.BytesToHash(accountStateRoot)
+				accountStateRoot, _ := localTxn.Hash()
+				accountStateTrie := localTxn.Commit()
+
+				// Add this to the cache
+				t.state.AddState(types.BytesToHash(accountStateRoot), accountStateTrie)
+
+				account.Root = types.BytesToHash(accountStateRoot)
+			}
+
+			if obj.DirtyCode {
+				t.state.SetCode(obj.CodeHash, obj.Code)
+			}
+
+			vv := account.MarshalWith(arena)
+			data := vv.MarshalTo(nil)
+
+			tt.Insert(hashit(obj.Address.Bytes()), data)
+			arena.Reset()
 		}
-
-		if a.DirtyCode {
-			t.state.SetCode(types.BytesToHash(a.Account.CodeHash), a.Code)
-		}
-
-		vv := a.Account.MarshalWith(arena)
-
-		/*
-			vv := arena.NewArray()
-			vv.Set(arena.NewUint(a.Account.Nonce))
-			vv.Set(arena.NewBigInt(a.Account.Balance))
-			vv.Set(arena.NewBytes(a.Account.Root.Bytes()))
-			vv.Set(arena.NewBytes(a.Account.CodeHash))
-		*/
-
-		data := vv.MarshalTo(nil)
-
-		tt.Insert(hashit(k), data)
-		arena.Reset()
-		return false
-	})
+	}
 
 	root, _ := tt.Hash()
 

--- a/state/immutable-trie/trie.go
+++ b/state/immutable-trie/trie.go
@@ -158,11 +158,12 @@ func (t *Trie) Commit(objs []*state.Object) (state.Snapshot, []byte) {
 				localTxn.batch = batch
 
 				for _, entry := range obj.Storage {
+					k := hashit(entry.Key)
 					if entry.Deleted {
-						localTxn.Delete(entry.Key)
+						localTxn.Delete(k)
 					} else {
 						vv := ar1.NewBytes(bytes.TrimLeft(entry.Val, "\x00"))
-						localTxn.Insert(entry.Key, vv.MarshalTo(nil))
+						localTxn.Insert(k, vv.MarshalTo(nil))
 					}
 				}
 

--- a/state/state.go
+++ b/state/state.go
@@ -19,7 +19,7 @@ type State interface {
 
 type Snapshot interface {
 	Get(k []byte) ([]byte, bool)
-	Commit(x *iradix.Tree) (Snapshot, []byte)
+	Commit(objs []*Object) (Snapshot, []byte)
 }
 
 // account trie
@@ -158,4 +158,27 @@ func (s *StateObject) Copy() *StateObject {
 	}
 
 	return ss
+}
+
+// Object is the serialization of the radix object (can be merged to StateObject?).
+type Object struct {
+	Address  types.Address
+	CodeHash types.Hash
+	Balance  *big.Int
+	Root     types.Hash
+	Nonce    uint64
+	Deleted  bool
+
+	// TODO: Move this to executor
+	DirtyCode bool
+	Code      []byte
+
+	Storage []*StorageObject
+}
+
+// StorageObject is an entry in the storage
+type StorageObject struct {
+	Deleted bool
+	Key     []byte
+	Val     []byte
 }

--- a/state/txn.go
+++ b/state/txn.go
@@ -7,12 +7,11 @@ import (
 	"math/big"
 	"strconv"
 
-	"golang.org/x/crypto/sha3"
-
 	iradix "github.com/hashicorp/go-immutable-radix"
 	lru "github.com/hashicorp/golang-lru"
 	"github.com/umbracle/minimal/crypto"
 	"github.com/umbracle/minimal/helper/hex"
+	"github.com/umbracle/minimal/helper/keccak"
 	"github.com/umbracle/minimal/state/runtime"
 	"github.com/umbracle/minimal/types"
 )
@@ -20,8 +19,6 @@ import (
 var (
 	ErrInsufficientBalanceForGas = errors.New("insufficient balance to pay for gas")
 )
-
-// var emptyCodeHash = crypto.Keccak256(nil)
 
 var emptyStateHash = types.StringToHash("0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421")
 
@@ -33,11 +30,6 @@ var (
 	refundIndex = types.BytesToHash([]byte{3}).Bytes()
 )
 
-type GasPool interface {
-	SubGas(uint64) error
-	AddGas(uint64)
-}
-
 // Txn is a reference of the state
 type Txn struct {
 	snapshot  Snapshot
@@ -45,7 +37,7 @@ type Txn struct {
 	snapshots []*iradix.Tree
 	txn       *iradix.Txn
 	codeCache *lru.Cache
-	hash      hashImpl
+	hash      *keccak.Keccak
 }
 
 func NewTxn(state State, snapshot Snapshot) *Txn {
@@ -63,16 +55,16 @@ func newTxn(state State, snapshot Snapshot) *Txn {
 		snapshots: []*iradix.Tree{},
 		txn:       i.Txn(),
 		codeCache: codeCache,
-		hash:      sha3.NewLegacyKeccak256().(hashImpl),
+		hash:      keccak.NewKeccak256(),
 	}
 }
 
-func (txn *Txn) hashit(dst, src []byte) []byte {
-	dst = extendByteSlice(dst, 32)
+func (txn *Txn) hashit(src []byte) []byte {
 	txn.hash.Reset()
 	txn.hash.Write(src)
-	txn.hash.Read(dst)
-	return dst
+	// hashit is used to make queries so we do not need to
+	// make copies of the result
+	return txn.hash.Read()
 }
 
 // Snapshot takes a snapshot at this point in time
@@ -118,7 +110,7 @@ func (txn *Txn) getStateObject(addr types.Address) (*StateObject, bool) {
 		return obj.Copy(), true
 	}
 
-	data, ok := txn.snapshot.Get(txn.hashit(nil, addr.Bytes()))
+	data, ok := txn.snapshot.Get(txn.hashit(addr.Bytes()))
 	if !ok {
 		return nil, false
 	}
@@ -285,24 +277,24 @@ func (txn *Txn) SetStorage(addr types.Address, key types.Hash, value types.Hash,
 	}
 
 	if original == current {
-		if original == (types.Hash{}) { // create slot (2.1.1)
+		if original == zeroHash { // create slot (2.1.1)
 			return runtime.StorageAdded
 		}
-		if value == (types.Hash{}) { // delete slot (2.1.2b)
+		if value == zeroHash { // delete slot (2.1.2b)
 			txn.AddRefund(15000)
 			return runtime.StorageDeleted
 		}
 		return runtime.StorageModified
 	}
-	if original != (types.Hash{}) {
-		if current == (types.Hash{}) { // recreate slot (2.2.1.1)
+	if original != zeroHash {
+		if current == zeroHash { // recreate slot (2.2.1.1)
 			txn.SubRefund(15000)
-		} else if value == (types.Hash{}) { // delete slot (2.2.1.2)
+		} else if value == zeroHash { // delete slot (2.2.1.2)
 			txn.AddRefund(15000)
 		}
 	}
 	if original == value {
-		if original == (types.Hash{}) { // reset to original inexistent slot (2.2.2.1)
+		if original == zeroHash { // reset to original inexistent slot (2.2.2.1)
 			txn.AddRefund(19800)
 		} else { // reset to original existing slot (2.2.2.2)
 			txn.AddRefund(4800)
@@ -318,10 +310,10 @@ func (txn *Txn) SetState(addr types.Address, key, value types.Hash) {
 			object.Txn = iradix.New().Txn()
 		}
 
-		if isZeros(value.Bytes()) {
-			object.Txn.Insert(txn.hashit(nil, key.Bytes()), nil)
+		if value == zeroHash {
+			object.Txn.Insert(key.Bytes(), nil)
 		} else {
-			object.Txn.Insert(txn.hashit(nil, key.Bytes()), value.Bytes())
+			object.Txn.Insert(key.Bytes(), value.Bytes())
 		}
 	})
 }
@@ -333,16 +325,16 @@ func (txn *Txn) GetState(addr types.Address, hash types.Hash) types.Hash {
 		return types.Hash{}
 	}
 
-	k := txn.hashit(nil, hash.Bytes())
-
 	if object.Txn != nil {
-		if val, ok := object.Txn.Get(k); ok {
+		if val, ok := object.Txn.Get(hash.Bytes()); ok {
 			if val == nil {
 				return types.Hash{}
 			}
 			return types.BytesToHash(val.([]byte))
 		}
 	}
+
+	k := txn.hashit(hash.Bytes())
 	return object.GetCommitedState(types.BytesToHash(k))
 }
 
@@ -412,8 +404,6 @@ func (txn *Txn) GetCodeHash(addr types.Address) types.Hash {
 	return types.BytesToHash(object.Account.CodeHash)
 }
 
-// Suicide
-
 // Suicide marks the given account as suicided
 func (txn *Txn) Suicide(addr types.Address) bool {
 	var suicided bool
@@ -468,7 +458,7 @@ func (txn *Txn) GetCommittedState(addr types.Address, hash types.Hash) types.Has
 	if !ok {
 		return types.Hash{}
 	}
-	return obj.GetCommitedState(types.BytesToHash(txn.hashit(nil, hash.Bytes())))
+	return obj.GetCommitedState(types.BytesToHash(txn.hashit(hash.Bytes())))
 }
 
 func (txn *Txn) TouchAccount(addr types.Address) {

--- a/state/txn_test.go
+++ b/state/txn_test.go
@@ -7,7 +7,6 @@ import (
 	"math/rand"
 	"testing"
 
-	iradix "github.com/hashicorp/go-immutable-radix"
 	"github.com/stretchr/testify/assert"
 	"github.com/umbracle/fastrlp"
 	"github.com/umbracle/minimal/helper/hex"
@@ -44,7 +43,7 @@ func (m *mockSnapshot) Get(k []byte) ([]byte, bool) {
 	return v, ok
 }
 
-func (m *mockSnapshot) Commit(x *iradix.Tree) (Snapshot, []byte) {
+func (m *mockSnapshot) Commit(objs []*Object) (Snapshot, []byte) {
 	panic("Not implemented in tests")
 }
 


### PR DESCRIPTION
Before, the trie insertion/hashing was done using a iradix object since it was the one used during the state transition. This PR removes that and introduces a new object that serializes the iradix into a list.